### PR TITLE
curl_multi_select for every 0.1 second, default 1s.

### DIFF
--- a/f1/Yun/Curl/Multi.php
+++ b/f1/Yun/Curl/Multi.php
@@ -84,7 +84,7 @@ class Yun_Curl_Multi {
             } while (CURLM_CALL_MULTI_PERFORM == $re);
 
             while ($still_running) {
-                if (-1 != curl_multi_select($multi_handler) ) {
+                if (-1 != curl_multi_select($multi_handler, 0.1) ) {
                     do {
                         curl_multi_exec($multi_handler, $still_running);
                     } while (CURLM_CALL_MULTI_PERFORM == $re);    


### PR DESCRIPTION
不设置此值的话，实际调用中每次并发调用最少也会达到1s的时间。
